### PR TITLE
Fix test case for plugin.configs access in src/myConfig.ts

### DIFF
--- a/tests/no-plugin-configs-access-from-src-configs.test.ts
+++ b/tests/no-plugin-configs-access-from-src-configs.test.ts
@@ -24,7 +24,7 @@ ruleTesterWithParser.run(
       {
         code: stripIndent`
         function myConfig(plugin: AlexPlugin) {
-            return createBaseConfig(plugin);
+            return plugin.configs.alexTypeScriptBase;
         }
 
         export default myConfig;


### PR DESCRIPTION
Accessing plugin.configs from outside the configs folder is fine - the helper is not needed there. That test was meant to test for if we access the property outside src/configs.