### PR TITLE
Add checks for it.only and it.skip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alextheman/eslint-plugin",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "ISC",
       "dependencies": {
         "common-tags": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/rules/no-isolated-tests.ts
+++ b/src/rules/no-isolated-tests.ts
@@ -21,7 +21,8 @@ const noIsolatedTests = createRule({
       CallExpression(node) {
         if (
           checkCallExpression(node, "describe", "only") ||
-          checkCallExpression(node, "test", "only")
+          checkCallExpression(node, "test", "only") ||
+          checkCallExpression(node, "it", "only")
         ) {
           return context.report({
             node,

--- a/src/rules/no-skipped-tests.ts
+++ b/src/rules/no-skipped-tests.ts
@@ -21,7 +21,8 @@ const noSkippedTests = createRule({
       CallExpression(node) {
         if (
           checkCallExpression(node, "describe", "skip") ||
-          checkCallExpression(node, "test", "skip")
+          checkCallExpression(node, "test", "skip") ||
+          checkCallExpression(node, "it", "skip")
         ) {
           return context.report({
             node,


### PR DESCRIPTION
it.only and it.skip would never be allowed under consistent-test-function with the default configuration, but it might be if someone changes their preference to it. They'd be wrong, but I guess as a package creator, I've gotta respect their opinions (even if it's wrong).