### PR TITLE
Add rule to enforce curly brackets around all codeblock statements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alextheman/eslint-plugin",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "ISC",
       "dependencies": {
         "common-tags": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "A package to provide custom ESLint rules and configs",
   "license": "ISC",
   "author": "alextheman",

--- a/src/configs/typeScriptBase.ts
+++ b/src/configs/typeScriptBase.ts
@@ -89,6 +89,7 @@ const typeScriptBase: Linter.Config[] = [
       "func-style": ["error", "declaration", { allowArrowFunctions: false }],
       "prefer-arrow-callback": ["error", { allowNamedFunctions: false }],
       "arrow-body-style": ["error", "always"],
+      curly: ["error", "all"],
       "no-param-reassign": "error",
       "no-useless-rename": "error",
       "sort-vars": "error",


### PR DESCRIPTION
This is generally better as it's easier to add/remove code to/from if the body's already prepared for it, even in the case where we only have one line.