### PR TITLE
Add scripts to allow us to run a local version of utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@alextheman/utility": "^2.20.0",
+        "@alextheman/utility": "^2.21.0",
         "@typescript-eslint/utils": "^8.47.0",
         "common-tags": "^1.8.2",
         "zod": "^4.1.12"
@@ -20,6 +20,7 @@
         "@types/eslint-plugin-jsx-a11y": "^6.10.1",
         "@types/node": "^24.10.1",
         "@typescript-eslint/rule-tester": "^8.47.0",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -39,8 +40,8 @@
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.47.0",
-        "vite-tsconfig-paths": "*",
-        "vitest": "*"
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^4.0.13"
       },
       "peerDependencies": {
         "eslint": ">=9.0.0",
@@ -55,8 +56,8 @@
         "eslint-plugin-react-hooks": ">=7.0.0",
         "eslint-plugin-react-refresh": ">=0.4.0",
         "typescript-eslint": ">=8.0.0",
-        "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^4.0.13"
+        "vite-tsconfig-paths": ">=5.1.4",
+        "vitest": ">=4.0.13"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -67,9 +68,9 @@
       "license": "MIT"
     },
     "node_modules/@alextheman/utility": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@alextheman/utility/-/utility-2.20.0.tgz",
-      "integrity": "sha512-vEPqX2N3RQIPff3Va6JT7arSqRiyRBWJimzOznzUre63jYuEQmGqirta73tRybZwVqNNGA5WSJmZ+7FX/dcPzw==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@alextheman/utility/-/utility-2.21.0.tgz",
+      "integrity": "sha512-2JJHbJsaRWPDTRDDQ/H0p0er7YPiTtP5ey52HPr/zL8dtzUgI7LNyCEUIJIEPSuwPPgI3c2Bs/B+hBA4FzM4zw==",
       "license": "ISC",
       "dependencies": {
         "zod": "^4.1.12"
@@ -3320,6 +3321,64 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^12.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "test": "vitest run",
     "test-watch": "vitest",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
-    "update-peer-dependencies": "bash -c 'npx npm-check-updates --dep peer -u \"$@\" && npm install' --"
+    "update-peer-dependencies": "bash -c 'npx npm-check-updates --dep peer -u \"$@\" && npm install' --",
+    "use-live-utility": "npm uninstall @alextheman/utility && npm install @alextheman/utility",
+    "use-local-utility": "dotenv -e .env -- sh -c 'UTILITY_PATH=${LOCAL_UTILITY_PATH:-../utility}; npm --prefix \"$UTILITY_PATH\" run create-local-package && npm uninstall @alextheman/eslint-plugin && npm install \"$UTILITY_PATH\"/alextheman-utility-*.tgz'"
   },
   "dependencies": {
-    "@alextheman/utility": "^2.20.0",
+    "@alextheman/utility": "^2.21.0",
     "@typescript-eslint/utils": "^8.47.0",
     "common-tags": "^1.8.2",
     "zod": "^4.1.12"
@@ -51,6 +53,7 @@
     "@types/eslint-plugin-jsx-a11y": "^6.10.1",
     "@types/node": "^24.10.1",
     "@typescript-eslint/rule-tester": "^8.47.0",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
May not be used as much given that utility functions tend to be tested thoroughly in utility before getting published so it's often safe to just publish and use the published version already, but it's helpful in cases where the build process is getting drastically changed and we want to test it works locally before publishing.