### PR TITLE
Captalise the 'c' in 'Changes'

### DIFF
--- a/docs/releases/patch/v4.8.6.md
+++ b/docs/releases/patch/v4.8.6.md
@@ -4,7 +4,7 @@
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 
-## Description of changes
+## Description of Changes
 
 - Set the severity of `jsdoc/require-jsdoc` rule in `personal/utility` config (used in `@alextheman/utility`) to `"error"`
     - Since my utility package has now fully adopted JSDoc comments, this enforces documentation on all future functions, preventing missing documentation from slipping through.


### PR DESCRIPTION
I'm picky lol

# Documentation Change

This is a change to the documentation of `@alextheman/eslint-plugin`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
