### PR TITLE
Change version number to v4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "4.8.6",
+  "version": "4.9.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v4.9.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Updates `eslint-plugin-perfectionist` to v5 to take advantage of new enhancements to sorting rules.
    - We now have more control over the grouping of the imports in `sort-imports`, so we can split groupings between internal type imports and external type imports better (likewise for value imports).
    - We can now sort wildcard exports (e.g. `export *`) as their own group, so we no longer need to have named exports and wildcard exports treated the same and sorted together.

## Additional Notes

- Since all of this affects my personal configs only, this is not a major change and I have kept `eslint-plugin-perfectionist` pinned at `>=4.0.0`.
- In the future, however, I will make `eslint-plugin-perfectionist` an optional dependency and pin it at `>=5.0.0`. This will be done once I feel ready to create a new major release of this plugin, which may be relatively soon, but not right now.
