### PR TITLE
Change version number to v4.9.1

### DIFF
--- a/docs/releases/patch/v4.9.1.md
+++ b/docs/releases/patch/v4.9.1.md
@@ -1,6 +1,6 @@
 # v4.9.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v4.9.1 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Sorts `package.json` as its own import group in the sorting rules in my personal ESLint configs.
    - I think package.json is currently being treated as an external import as of now, which isn't quite ideal. I would like it to be treated as its own thing, listed after the main internal ones, as even though it is an internal package, it still feels distinct enough to want to be treated separately.
- Sorts `tests` as its own import group.
    - These now occur as their own group before the internal imports (considered as imports from `src`).

## Additional Notes

This is only a patch change because it only affects configs within the `personal` config group, which are already not considered stable enough for public usage. As such, these changes should have barely any effect on anyone using the package other than myself.
