### PR TITLE
Change version number to v4.9.2

### DIFF
--- a/docs/releases/patch/v4.9.2.md
+++ b/docs/releases/patch/v4.9.2.md
@@ -1,6 +1,6 @@
 # v4.9.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v4.9.2 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- This is just a test release to test the new automatic `commit-version-change` workflow. Previously we had to workflow_dispatch, but I have refactored it so that it could potentially work with a push onto main.

## Additional Notes

See https://github.com/AlexMan123456/github-actions/blob/main/docs/releases/major/v3.0.0.md for more information.
