### PR TITLE
Change version number to v4.10.0

### DIFF
--- a/docs/releases/minor/v4.10.0.md
+++ b/docs/releases/minor/v4.10.0.md
@@ -1,6 +1,6 @@
 # v4.10.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "4.9.2",
+  "version": "4.10.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v4.10.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a rule to the `general/javascript` ruleset that forbids usage of bare imports of Node dependencies.
    - I added this rule because not having it there makes it easy for accidental usage of a built-in Node dependency to slip through. That is, someone may publish a package called `fs` on the NPM registry, and if you have that installed into your project, that would take precedence over the actual built-in `fs`. You can also imagine this would be particularly bad if you had that alternative `fs` globally installed.
    - As such, prefixing built-in Node dependency imports with `node:` makes the intent clearer and guarantees that you will always use the built-in module.

## Additional Notes

- I marked this as a minor change because it affects a config in the `general` group, which are ones intended for public usage. Anyone using the `general/javascript` or `general/typescript` configs are affected by this.
- However, the amount of work required to refactor this is small - just run the ESLint fixer. It's a fixable rule, so it will go through and replace all instances of, say, `import { writeFile } from "fs";` with `import { writeFile } from "node:fs"`.
