### PR TITLE
Rename all types specific to my plugin to be prefixed with 'Alex'

### DIFF
--- a/src/configs/AlexPluginConfigGroup.ts
+++ b/src/configs/AlexPluginConfigGroup.ts
@@ -32,8 +32,8 @@ export interface AlexPluginConfigGroup {
   combined: Record<CombinedConfig, Linter.Config[]>;
 }
 
-export type ConfigGroupName = keyof AlexPluginConfigGroup;
-export type ConfigKey = {
-  [Group in ConfigGroupName &
+export type AlexConfigGroupName = keyof AlexPluginConfigGroup;
+export type AlexConfigKey = {
+  [Group in AlexConfigGroupName &
     string]: `${CamelToKebab<Group>}/${CamelToKebab<keyof AlexPluginConfigGroup[Group] & string>}`;
-}[ConfigGroupName & string];
+}[AlexConfigGroupName & string];

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,7 +1,7 @@
 import type { Linter } from "eslint";
 
 import type { AlexPlugin } from "src/alexPlugin";
-import type { ConfigKey } from "src/configs/AlexPluginConfigGroup";
+import type { AlexConfigKey } from "src/configs/AlexPluginConfigGroup";
 
 import {
   combinedJavaScript,
@@ -34,7 +34,9 @@ import {
 import { pluginBase, pluginTests } from "src/configs/plugin";
 import createPluginConfigs from "src/utility/private/createPluginConfigs";
 
-function createAlexPluginConfigs(plugin: Readonly<AlexPlugin>): Record<ConfigKey, Linter.Config[]> {
+function createAlexPluginConfigs(
+  plugin: Readonly<AlexPlugin>,
+): Record<AlexConfigKey, Linter.Config[]> {
   return createPluginConfigs({
     combined: {
       javaScript: [...combinedJavaScript(plugin), ...generalPackageJson],

--- a/src/utility/private/createConfigGroup.ts
+++ b/src/utility/private/createConfigGroup.ts
@@ -1,13 +1,13 @@
 import type { Linter } from "eslint";
 
-import type { ConfigGroupName, ConfigKey } from "src/configs/AlexPluginConfigGroup";
+import type { AlexConfigGroupName, AlexConfigKey } from "src/configs/AlexPluginConfigGroup";
 
 import camelToKebab from "src/utility/private/camelToKebab";
 
 function createConfigGroup(
-  group: ConfigGroupName,
+  group: AlexConfigGroupName,
   configs: Record<string, Linter.Config[]>,
-): Record<ConfigKey, Linter.Config[]> {
+): Record<AlexConfigKey, Linter.Config[]> {
   const newConfigs: Record<string, Linter.Config[]> = {};
   for (const key in configs) {
     newConfigs[`${camelToKebab(group)}/${camelToKebab(key)}`] = configs[key];

--- a/src/utility/private/createPluginConfigs.ts
+++ b/src/utility/private/createPluginConfigs.ts
@@ -1,17 +1,19 @@
 import type { Linter } from "eslint";
 
-import type { AlexPluginConfigGroup, ConfigKey } from "src/configs/AlexPluginConfigGroup";
+import type { AlexPluginConfigGroup, AlexConfigKey } from "src/configs/AlexPluginConfigGroup";
 
 import createConfigGroup from "src/utility/private/createConfigGroup";
 
-function createPluginConfigs(config: AlexPluginConfigGroup): Record<ConfigKey, Linter.Config[]> {
-  const allConfigs = {} as Record<ConfigKey, Linter.Config[]>;
+function createPluginConfigs(
+  config: AlexPluginConfigGroup,
+): Record<AlexConfigKey, Linter.Config[]> {
+  const allConfigs = {} as Record<AlexConfigKey, Linter.Config[]>;
   for (const configGroupEntries of Object.entries(config) as Parameters<
     typeof createConfigGroup
   >[]) {
     Object.assign(allConfigs, createConfigGroup(...configGroupEntries));
   }
-  return allConfigs satisfies Record<ConfigKey, Linter.Config[]>;
+  return allConfigs satisfies Record<AlexConfigKey, Linter.Config[]>;
 }
 
 export default createPluginConfigs;


### PR DESCRIPTION
This will make it a lot clearer that these types affect my plugin specifically. This will be helpful especially as I start to make the main createConfigGroup and createPluginConfigs function more generic so that they work for any plugin.

# Breaking Change

This is a change to `@alextheman/eslint-plugin` that will cause breaking changes wherever it is used.

Please see the commits tab of this pull request for the description of changes.
