### PR TITLE
Add v5 branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v5" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "v5" ]
 
 jobs:
   ci:


### PR DESCRIPTION
I am going to start work on the next major version on its own branch. That way, I can treat this v5 space separately from the main branch and keep on progressing on that, then just merge all v5 features into main in one go. This makes it easier to keep track of all major changes without needing to keep committing them to main, so I am still open to making new minor/patch releases without disrupting major work.

# Tooling Change

This is a change to the tooling of `@alextheman/eslint-plugin`. It changes the internal workings of the package that should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
