### PR TITLE
Remove push to v5 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "v5" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main", "v5" ]
 


### PR DESCRIPTION
The pull request to main will trigger the CI job anyway, so it is redundant to require CI on push to v5 as well.

# Tooling Change

This is a change to the tooling of `@alextheman/eslint-plugin`. It changes the internal workings of the package that should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
