### PR TITLE
Add release note for v5

### DIFF
--- a/docs/releases/major/v5.0.0.md
+++ b/docs/releases/major/v5.0.0.md
@@ -1,0 +1,58 @@
+# v5.0.0 (Major Release)
+
+**Status**: In progress
+
+This is a new major release of the `@alextheman/eslint-plugin` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.
+
+## Description of Changes
+
+- We now export the `flattenConfigs` function, which can be used to turn any object into a valid flattened object that can be passed as configs on an ESLint plugin. For example:
+
+```typescript
+flattenConfigs<AlexPluginConfigGroup>({
+   general: {
+        typescript: generalTypeScriptConfig,
+        javascript: generalJavaScriptConfig,
+        react: generalReactConfig,
+        // ...
+    }
+    plugin: {
+        base: pluginBaseConfig,
+        tests: pluginTestsConfig,
+        // ...
+    }
+})
+
+// Returns
+{
+  "general/typescript": generalTypeScriptConfig,
+  "general/javascript": generalJavaScriptConfig,
+  "general/react": generalReactConfig,
+  // ...,
+  "plugin/base": pluginBaseConfig,
+  "plugin/tests": pluginTestsConfig,
+  // ...
+};
+```
+
+Note that if you provide the rules config directly, you will need to add a `satisfies Linter.Config[]` to ensure that the function recognises the rules config as an actual rules config object.
+
+```typescript
+flattenConfigs<AlexPluginConfigGroup>({
+   general: {
+        typescript: [
+            {
+                rules: {
+                    "prefer-const": "error"
+                    // ...
+                }
+            }
+        ] satisfies Linter.Config[]
+})
+```
+
+## Migration Notes
+
+- Wherever the `ConfigGroupName` type was being used, replace this with `AlexConfigGroupObject`.
+- Also replace `ConfigKey` with `AlexConfigKey` or `GetFlattenedConfigNames<AlexPluginConfigObject>`.
+- The exported `GeneralConfig` and `PluginConfig` types now have a lowercase s for `javascript` and `typescript`. This is because it broke the `CamelToKebab` type when the s was uppercase and I tried making an exception for it.


### PR DESCRIPTION
# Documentation Change

This is a change to the documentation of `@alextheman/eslint-plugin`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
