### PR TITLE
Enable the recommended config from eslint-plugin-n in general/javascript

### DIFF
--- a/src/configs/general/javaScript.ts
+++ b/src/configs/general/javaScript.ts
@@ -12,6 +12,7 @@ import unusedVarsIgnorePatterns from "src/configs/helpers/unusedVarsIgnorePatter
 const generalJavaScript: Linter.Config[] = [
   js.configs.recommended,
   prettierConfig,
+  nodePlugin.configs["flat/recommended"],
   {
     files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
     ignores: ["dist"],
@@ -24,6 +25,19 @@ const generalJavaScript: Linter.Config[] = [
     rules: {
       eqeqeq: "error",
       "import/no-unresolved": "error",
+      "n/file-extension-in-import": [
+        "error",
+        "always",
+        {
+          ".js": "never",
+          ".jsx": "never",
+          ".ts": "never",
+          ".tsx": "never",
+        },
+      ],
+      // Gives false positives and is already covered by import/no-unresolved (or the TypeScript compiler in TypeScript projects)
+      "n/no-missing-import": "off",
+      "n/no-path-concat": "error",
       "n/prefer-node-protocol": "error",
       "no-cond-assign": "error",
       "no-console": ["error", { allow: ["warn", "error", "info"] }],

--- a/src/utility/private/checkConfigChanges.ts
+++ b/src/utility/private/checkConfigChanges.ts
@@ -10,9 +10,11 @@ const previousHash = fs.existsSync(hashFile) ? fs.readFileSync(hashFile, "utf-8"
 
 if (currentHash === previousHash) {
   console.info("Configs unchanged. Skipping build.");
+  // eslint-disable-next-line n/no-process-exit
   process.exit(0);
 } else {
   fs.writeFileSync(hashFile, currentHash);
   console.info("Configs changed. Running build...");
+  // eslint-disable-next-line n/no-process-exit
   process.exit(1);
 }

--- a/tests/rule-testers/rule-tester-with-parser.ts
+++ b/tests/rule-testers/rule-tester-with-parser.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
+import tseslint from "typescript-eslint";
 
 import path from "node:path";
 
@@ -11,8 +12,7 @@ export function getProjectRelativePath(pathname: string): string {
 const ruleTesterWithParser = new RuleTester({
   languageOptions: {
     ecmaVersion: "latest",
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    parser: require("@typescript-eslint/parser"),
+    parser: tseslint.parser,
     parserOptions: {
       tsconfigRootDir: basePath,
       project: `${basePath}/tsconfig.json`,


### PR DESCRIPTION
These rules enforce further best practices around syntax and import paths depending on whether you're using CommonJS or ES Modules. I have already gone through and dealt with rules from this config that conflict with other rules and/or give false positives, so it should mostly be fine and not require too much refactoring, but it is best to see what happens in other projects once this goes live and see what edge cases need to be fixed.

# Breaking Change

This is a change to `@alextheman/eslint-plugin` that will cause breaking changes wherever it is used.

Please see the commits tab of this pull request for the description of changes.
