### PR TITLE
Add eslint-plugin-n to release docs

### DIFF
--- a/docs/releases/major/v5.0.0.md
+++ b/docs/releases/major/v5.0.0.md
@@ -6,7 +6,7 @@ This is a new major release of the `@alextheman/eslint-plugin` package. It has t
 
 ## Description of Changes
 
-- We now export the `flattenConfigs` function, which can be used to turn any object into a valid flattened object that can be passed as configs on an ESLint plugin. For example:
+- We now export the `flattenConfigs` function, which can be used to turn a nested config object into a valid flattened object that can be passed to ESLint as plugin configs. For example:
 
 ```typescript
 flattenConfigs<AlexPluginConfigGroup>({
@@ -51,8 +51,13 @@ flattenConfigs<AlexPluginConfigGroup>({
 })
 ```
 
+- On top of this, the recommended config from `eslint-plugin-n` has been enabled in the `general/javascript` config, and by extension the `general/typescript` config. It enforces best practice for Node applications particularly, although there does seem to still be some that may be relevant for React projects.
+- I have also added some additional rules that weren't enabled by default from `eslint-plugin-n`, the biggest one being I enforce that file extensions on TypeScript/JavaScript file imports should not be present, but for any other file, it must be there.
+
 ## Migration Notes
 
 - Wherever the `ConfigGroupName` type was being used, replace this with `AlexConfigGroupObject`.
 - Also replace `ConfigKey` with `AlexConfigKey` or `GetFlattenedConfigNames<AlexPluginConfigObject>`.
 - The exported `GeneralConfig` and `PluginConfig` types now have a lowercase s for `javascript` and `typescript`. This is because it broke the `CamelToKebab` type when the s was uppercase and I tried making an exception for it.
+- If you are using `general/javascript` or `general/typescript`, run ESLint in your project and fix any reported errors from `eslint-plugin-n`. I have already gone through my own projects and disabled any conflicting rules myself, but if I happened to have enabled rules that conflict with some of your config's rules, you will need to choose whether to follow the new rule or your existing config.
+- In particular, if you're importing JavaScript/TypeScript files using the file extensions, you will need to get rid of them in order to comply with `n/file-extension-in-import`.


### PR DESCRIPTION
It does feel like a nice extra thing to add and I am mostly following this config in my projects anyway (bar the process.exit rule that I can refactor, especially as AlexCLine gets its next major version), and given that I've already enabled one rule from the plugin to protect against bare imports of node dependencies, I figured it'd be nice to just enable the whole recommeded config. It does not conflict too much with my existing rules and the main rule that did has been disabled.

# Documentation Change

This is a change to the documentation of `@alextheman/eslint-plugin`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
