### PR TITLE
Disable n/hashbang in alex-c-line

### DIFF
--- a/src/configs/personal/alexCLine.ts
+++ b/src/configs/personal/alexCLine.ts
@@ -1,13 +1,24 @@
 import type { Linter } from "eslint";
 
+import nodePlugin from "eslint-plugin-n";
 import perfectionist from "eslint-plugin-perfectionist";
 
 import sortObjects from "src/configs/helpers/sorting/sortObjects";
 
 const personalAlexCLine: Linter.Config[] = [
   {
-    files: ["src/commands/index.ts"],
+    files: ["src/**/*.ts"],
     name: "@alextheman/personal/alex-c-line",
+    plugins: {
+      n: nodePlugin,
+    },
+    rules: {
+      // Gives a false positive on the entry file where it is actually needed
+      "n/hashbang": "off",
+    },
+  },
+  {
+    files: ["src/commands/index.ts"],
     plugins: {
       perfectionist,
     },


### PR DESCRIPTION
It gives a false positive on the entry file that does need this.

# Bug Fix

This is a bug fix for `@alextheman/eslint-plugin`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
