### PR TITLE
Change version number to v5.0.0

### DIFF
--- a/docs/releases/major/v5.0.0.md
+++ b/docs/releases/major/v5.0.0.md
@@ -1,6 +1,6 @@
 # v5.0.0 (Major Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new major release of the `@alextheman/eslint-plugin` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "4.10.0",
+  "version": "5.0.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.0.0 (Major Release)

**Status**: Released

This is a new major release of the `@alextheman/eslint-plugin` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.

## Description of Changes

- We now export the `flattenConfigs` function, which can be used to turn a nested config object into a valid flattened object that can be passed to ESLint as plugin configs. For example:

```typescript
flattenConfigs<AlexPluginConfigGroup>({
   general: {
        typescript: generalTypeScriptConfig,
        javascript: generalJavaScriptConfig,
        react: generalReactConfig,
        // ...
    }
    plugin: {
        base: pluginBaseConfig,
        tests: pluginTestsConfig,
        // ...
    }
})

// Returns
{
  "general/typescript": generalTypeScriptConfig,
  "general/javascript": generalJavaScriptConfig,
  "general/react": generalReactConfig,
  // ...,
  "plugin/base": pluginBaseConfig,
  "plugin/tests": pluginTestsConfig,
  // ...
};
```

Note that if you provide the rules config directly, you will need to add a `satisfies Linter.Config[]` to ensure that the function recognises the rules config as an actual rules config object.

```typescript
flattenConfigs<AlexPluginConfigGroup>({
   general: {
        typescript: [
            {
                rules: {
                    "prefer-const": "error"
                    // ...
                }
            }
        ] satisfies Linter.Config[]
})
```

- On top of this, the recommended config from `eslint-plugin-n` has been enabled in the `general/javascript` config, and by extension the `general/typescript` config. It enforces best practice for Node applications particularly, although there does seem to still be some that may be relevant for React projects.
- I have also added some additional rules that weren't enabled by default from `eslint-plugin-n`, the biggest one being I enforce that file extensions on TypeScript/JavaScript file imports should not be present, but for any other file, it must be there.

## Migration Notes

- Wherever the `ConfigGroupName` type was being used, replace this with `AlexConfigGroupObject`.
- Also replace `ConfigKey` with `AlexConfigKey` or `GetFlattenedConfigNames<AlexPluginConfigObject>`.
- The exported `GeneralConfig` and `PluginConfig` types now have a lowercase s for `javascript` and `typescript`. This is because it broke the `CamelToKebab` type when the s was uppercase and I tried making an exception for it.
- If you are using `general/javascript` or `general/typescript`, run ESLint in your project and fix any reported errors from `eslint-plugin-n`. I have already gone through my own projects and disabled any conflicting rules myself, but if I happened to have enabled rules that conflict with some of your config's rules, you will need to choose whether to follow the new rule or your existing config.
- In particular, if you're importing JavaScript/TypeScript files using the file extensions, you will need to get rid of them in order to comply with `n/file-extension-in-import`.
