### PR TITLE
Change version number to v5.0.1

### DIFF
--- a/docs/releases/patch/v5.0.1.md
+++ b/docs/releases/patch/v5.0.1.md
@@ -1,6 +1,6 @@
 # v5.0.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.0.1 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Adds the `@deprecated` tag to the `personal/typescript-package` config
    - I want the deprecated tag to be listed as the first tag in the JSDoc comments. That way, it takes precedence over the rest of the tags as it should communicate the intent that the thing should not be used before getting into the information about the usage itself.

## Additional Notes

- Since it is a personal config, it is only a patch release and should not affect any other repositories beyond my own.
