### PR TITLE
Change version number to v5.1.0

### DIFF
--- a/docs/releases/minor/v5.1.0.md
+++ b/docs/releases/minor/v5.1.0.md
@@ -1,6 +1,6 @@
 # v5.1.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.1.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Pins `eslint-plugin-perfectionist` to >=5
    - This was meant to be done during the actual v5 release of this package, but I forgot. Hence I am following it up in this minor release while it's early.
    - This is being done because I am using new features of `eslint-plugin-perfectionist` in my personal configs, and so it is no longer compatible with v4.

## Additional Notes

- This change should hopefully not affect you if you don't have `eslint-plugin-perfectionist` installed in your repositories at less than v5. If you do, please consider updating that package anyway because a lot of the sorting rules there are far more flexible than they were in v4 and I think it's worth it.
- If you aren't ready to update that package, though, please pin this plugin to a version that is compatible with v4.
