### PR TITLE
Change version number to v5.2.0

### DIFF
--- a/docs/releases/minor/v5.2.0.md
+++ b/docs/releases/minor/v5.2.0.md
@@ -1,6 +1,6 @@
 # v5.2.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.2.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds the category tag to `personal/typescript-package`.
    - This will be needed for better left tab grouping in generated `@alextheman/utility` docs.
- Adds a TypeDoc Config to be used in utility for now, but eventually also in components and this package.
    - All that JSDoc work I have been doing will pay off once this releases! I have finally settled on a good documentation strategy that is maintainable and, because the generation of them is automated, will never go too out-of-drift with actual package work like the old package-docs site did!

## Additional Notes

- As stated above, this is currently being tested in `@alextheman/utility` as its JSDoc comments are the most complete as of now.
- Once it has been tested there and once `@alextheman/components` also gets its JSDoc comments, it will also get generated docs. That does mean that it might lose out on that interactivity that the old package-docs had, where you can see what the rendered component looks like and have a play around with it, which does kinda suck, but it at least means that it won't go out-of-sync with the current package state as it's not as difficult to maintain JSDoc comments compared to an entire docs React app.
- As for `@alextheman/eslint-plugin`, the public utilities have JSDoc comments as of now, so I can generate documentation for that. However, I think the rules and configs may need to be treated separately, as rules generally tend to have their own metadata stored on them already, which makes JSDoc redundant in that case, and configs are difficult to add JSDoc comments to at the moment due to the fact that they are created dynamically using the config creators.
