### PR TITLE
Change version number to v5.2.1

### DIFF
--- a/docs/releases/patch/v5.2.1.md
+++ b/docs/releases/patch/v5.2.1.md
@@ -1,6 +1,6 @@
 # v5.2.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.2.1 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Disables sources in TypeDoc config.
    - This was causing noisy diffs where the links to the source code in the repository changed on re-generation every single time. Given that this rule doesn't seem that worth it anyway (docs are really supposed to get rid of the need to see the source code in the first place), I have disabled this.
