### PR TITLE
Change version number to v5.2.2

### DIFF
--- a/docs/releases/patch/v5.2.2.md
+++ b/docs/releases/patch/v5.2.2.md
@@ -1,6 +1,6 @@
 # v5.2.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.2.2 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Disables the `n/no-unpublished-import` in `general/javascript`
    - It was giving false positives when using `prisma` and `dotenv`, for some reason, even though they are probably fine to use considering I have literally installed them and used them.
