### PR TITLE
Change version number to v5.2.3

### DIFF
--- a/docs/releases/patch/v5.2.3.md
+++ b/docs/releases/patch/v5.2.3.md
@@ -1,6 +1,6 @@
 # v5.2.3 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.2.3 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Removes all imports from `src/index` in the plugin.
    - Probably not the best idea to import from the package's entrypoint within the package itself.
    - It kinda works, but it is a little risky considering that if the plugin is trying to import from the entrypoint, but a given file is also trying to export from the same entrypoint, you may end up with a partially resolved thing when you try using it.

## Additional Notes

- Probably should've done this sooner, but better late than never, I suppose.
