### PR TITLE
Change version number to v5.3.0

### DIFF
--- a/docs/releases/minor/v5.3.0.md
+++ b/docs/releases/minor/v5.3.0.md
@@ -1,6 +1,6 @@
 # v5.3.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.3.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Tidy up the export space of the package a little bit
    - The public utilities are now being exported from a separate utility subdomain in addition to the root. That way, you can import a helper utility from `@alextheman/eslint-plugin` or from `@alextheman/eslint-plugin/utility`.
- Renames the `prettierRules` to `prettierConfig`.
- Some internal helpers are no longer being exported. Most of the helper functions themselves are so it should still cause little breakage, but if you were relying on a type or a internal config object, it's most likely not being exported.
    - They were unstable anyway as it often changed between minor/patch releases so you should not really have been relying on them, but if you were, please bear that in mind.
- Some minor internal directory refactors have taken place, which shouldn't really affect consumers of the package.

## Additional Notes

- This is all work being done to prepare this package for its documentation refactor. The public utilities will most likely have their docs generated similarly to how `@alextheman/utility` has them generated (through TypeDoc), but the rules and configs may differ slightly. In any case, keep an eye out for any further announcements regarding documentation for this package.
- Also, I was debating whether this should be a major or minor change, and I went with minor just because I felt that the removed exports here are just more internal removals for things that should not be used anyway. We already had a new major release just a few weeks ago, so marking this one as a new major didn't quite feel right.
