### PR TITLE
Change version number to v5.4.0

### DIFF
--- a/docs/releases/minor/v5.4.0.md
+++ b/docs/releases/minor/v5.4.0.md
@@ -1,6 +1,6 @@
 # v5.4.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.4.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/eslint-plugin` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Changes the TypeDoc config to be a function that returns the config.
    - This allows us to change the entrypoint, which is needed for the docs generation in this plugin as we only really want the public utilities to be documented with TypeDoc. The rules and configs will be treated separately.

## Migration Notes

- If you are using my TypeDoc config, please now invoke the config as a function. Example:

#### Before

```typescript
import { typeDocConfig } from "@alextheman/eslint-plugin";

export default typeDocConfig;
```

#### After

```typescript
import { typeDocConfig } from "@alextheman/eslint-plugin";

export default typeDocConfig();
```

You may also change the entrypoint by providing an array of strings (e.g. `typeDocConfig(["./src/utility/public/index.ts"])`)
