### PR TITLE
Change version number to v5.4.1

### DIFF
--- a/docs/releases/patch/v5.4.1.md
+++ b/docs/releases/patch/v5.4.1.md
@@ -1,6 +1,6 @@
 # v5.4.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.4.1 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Disables the `n/no-extraneous-import` rule in my personal Neurosongs configs.
    - This rule is giving false positives there because it does not recognise global workspace packages. Since `@alextheman/utility` is considered a global workspace package in Neurosongs 2, we get false positives wherever we try and import from it. Hence, I need to disable the rule in this repository.

## Additional Notes

See https://github.com/eslint-community/eslint-plugin-n/issues/209 for more information regarding the bug.
