### PR TITLE
Change version number to v5.4.2

### DIFF
--- a/docs/releases/patch/v5.4.2.md
+++ b/docs/releases/patch/v5.4.2.md
@@ -1,6 +1,6 @@
 # v5.4.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/eslint-plugin",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "A package to provide custom ESLint rules and configs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v5.4.2 (Patch Release)

**Status**: Released

This is a new patch release of the `@alextheman/eslint-plugin` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Adds outputOptions to internal tsdown config.
    - This is needed to get rid of a warning about named and default exports with tsdown.
    - It is not expected to affect anyone's use cases, but considering that the build process has changed, I decided to change the version here just in case it does have an effect on other projects using the plugin.
