### PR TITLE
Add a full stop in description field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alextheman/eslint-plugin",
   "version": "5.4.2",
-  "description": "A package to provide custom ESLint rules and configs",
+  "description": "A package to provide custom ESLint rules and configs.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/AlexMan123456/eslint-plugin.git"


### PR DESCRIPTION
I am pedantic.

# Documentation Change

This is a change to the documentation of `@alextheman/eslint-plugin`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
