### PR TITLE
Add logs to end-to-end test

### DIFF
--- a/tests/end-to-end/entrypoints.test.ts
+++ b/tests/end-to-end/entrypoints.test.ts
@@ -49,7 +49,7 @@ const describe = parseBoolean(process.env.RUN_END_TO_END ?? "false")
   : describeVitest.skip;
 
 describe("Entrypoint for @alextheman/eslint-plugin", () => {
-  describe.each<PackageManager>(["npm", "pnpm"])("Package manager %s", (packageManager) => {
+  describe.each<PackageManager>(["pnpm"])("Package manager %s", (packageManager) => {
     test.each<ModuleType>(["commonjs", "module", "typescript"])(
       "Module type %s",
       async (moduleType) => {


### PR DESCRIPTION
Should help in determining where exactly the slowest part of the test is.

# Tooling Change

This is a change to the tooling of `@alextheman/eslint-plugin`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
