### PR TITLE
Update workflows and run dependency audits on lockfile change

### DIFF
--- a/.github/workflows/audit-javascript-dependencies.yml
+++ b/.github/workflows/audit-javascript-dependencies.yml
@@ -3,13 +3,15 @@ name: Audit dependencies
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "**/pnpm-lock.yaml"
 
 jobs:
   audit-javascript-dependencies:
     permissions:
       contents: read
       pull-requests: write
-    uses: alextheman231/github-actions/.github/workflows/audit-javascript-dependencies.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/audit-javascript-dependencies.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     with:
       pull-request-number: ${{ github.event.pull_request.number }}
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ permissions:
 
 jobs:
   package-ci:
-    uses: alextheman231/github-actions/.github/workflows/package-ci.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/package-ci.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
 
   actions-ci:
-    uses: alextheman231/github-actions/.github/workflows/actions-ci.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/actions-ci.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
 
   end-to-end-ci:
-    uses: alextheman231/github-actions/.github/workflows/end-to-end-node-package-ci.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/end-to-end-node-package-ci.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1

--- a/.github/workflows/commit-version-change.yml
+++ b/.github/workflows/commit-version-change.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
       pull-requests: write
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     with:
       version-type: major
     secrets:
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: write
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     with:
       version-type: minor
     secrets:
@@ -34,7 +34,7 @@ jobs:
       contents: write
       pull-requests: write
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     with:
       version-type: patch
     secrets:

--- a/.github/workflows/create-feature-docs.yml
+++ b/.github/workflows/create-feature-docs.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   create-feature-docs:
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/create-feature-docs.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/create-feature-docs.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/create-pull-request-templates.yml
+++ b/.github/workflows/create-pull-request-templates.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   create-pull-request-templates:
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/create-pull-request-templates.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/create-pull-request-templates.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,14 @@ jobs:
     permissions:
       id-token: write
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/npm-registry-publish.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/npm-registry-publish.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
 
   create-github-release:
     needs: npm-registry-publish
     permissions:
       contents: write
     if: needs.npm-registry-publish.outputs.did_publish == 'true'
-    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/restrict-alex-up-bot-branches.yml
+++ b/.github/workflows/restrict-alex-up-bot-branches.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   restrict-alex-up-bot-branches:
-    uses: alextheman231/github-actions/.github/workflows/restrict-alex-up-bot-branches.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/restrict-alex-up-bot-branches.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/scheduled-patch-release.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/scheduled-patch-release.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   update-dependencies:
     if: ${{ github.repository == 'alextheman231/eslint-plugin' }}
-    uses: alextheman231/github-actions/.github/workflows/update-dependencies.yml@3a7c224f60dbd26c8e2f31738236b6cbc8dd96e7 # v12.0.0
+    uses: alextheman231/github-actions/.github/workflows/update-dependencies.yml@5a51ff516a9036a0f71712e2028f28d7e6fe955b # v12.0.1
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
This gets rid of the condition that the workflow only runs on the update-dependencies alex-up-bot branch, and changes the condition in which it runs so that it runs on any change to the lockfile, which is a better indicator in general for if dependencies have changed.

# Tooling Change

This is a change to the tooling of `@alextheman/eslint-plugin`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
